### PR TITLE
Fixed testNonGenericParameter

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/MethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/MethodCallProxyTest.java
@@ -4,9 +4,10 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.test.utility.CallTraceable;
 import net.bytebuddy.utility.RandomString;
 import org.junit.Test;
-
+import java.lang.reflect.Field;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
+import java.util.Vector;
 import java.util.concurrent.Callable;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -81,8 +82,12 @@ public class MethodCallProxyTest extends AbstractMethodCallProxyTest {
         Class<?> auxiliaryType = proxyOnlyDeclaredMethodOf(GenericType.class);
         assertThat(auxiliaryType.getTypeParameters().length, is(0));
         assertThat(auxiliaryType.getDeclaredMethod("call").getGenericReturnType(), is((Type) Object.class));
-        assertThat(auxiliaryType.getDeclaredFields()[1].getGenericType(), is((Type) Object.class));
-        assertThat(auxiliaryType.getDeclaredFields()[2].getGenericType(), is((Type) Number.class));
+        Vector<Type> t = new Vector<Type>();
+        for(Field x: auxiliaryType.getDeclaredFields()){
+            t.add(x.getGenericType());
+        }
+        assertThat(t.contains((Type) Object.class),is(true));
+        assertThat(t.contains((Type) Number.class),is(true));
     }
 
     @Test


### PR DESCRIPTION
**Issue:**
The testNonGenericParameter test method is verifying specific properties of the auxiliaryType class. Some of the checks (Line [84](https://github.com/raphw/byte-buddy/blob/master/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/MethodCallProxyTest.java#L84), [85](https://github.com/raphw/byte-buddy/blob/master/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/MethodCallProxyTest.java#L85)) are to check if the generic type of 2nd declared field is of type Object.class and 3rd declared field is of type Number.class. However, the getDeclaredFields() used to access the 2nd and 3rd class fields is a non-deterministic function which doesn't guarantee a specific order of fields ([Source](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)). As there is no guarantee regarding the order of the returned fields, the test is failing due to differences in fields' ordering.

**Solution:**
The last 2 assert statement where the test is failing is trying to check if the class has one field of type Object.class and one field of type Number.class. To achieve this target, rather than explicitly accessing specific index of list returned by getDeclaredFields, we are checking if the list of fields' type contains the 2 mentioned types. This removes the dependency of a field being at a specific index and thus, fixes the test.

**Steps to reproduce the error that causes the testNonGenericParameter to fail:**
Install nondex tool. Installation instructions can be found at https://github.com/TestingResearchIllinois/NonDex.
git clone https://github.com/saurabh-shetty/byte-buddy/
cd byte-buddy
mvn install -pl byte-buddy-dep -am -DskipTests (BUILD SUCCESS)
mvn -pl byte-buddy-dep edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=net.bytebuddy.implementation.auxiliary.MethodCallProxyTest#testNonGenericParameter

Please review and consider merging this pull request.