### PR TITLE
Fixed Test net.bytebuddy.description.type.TypeDescriptionArrayProjectionTest.testTypeAnnotationExceptionType

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionArrayProjectionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionArrayProjectionTest.java
@@ -7,7 +7,9 @@ import org.junit.rules.MethodRule;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Comparator;
 import static org.mockito.Mockito.mock;
 
 public class TypeDescriptionArrayProjectionTest extends AbstractTypeDescriptionTest {
@@ -35,6 +37,13 @@ public class TypeDescriptionArrayProjectionTest extends AbstractTypeDescriptionT
     }
 
     protected TypeDescription.Generic describeExceptionType(Method method, int index) {
+        Type[] exceptionTypes = method.getGenericExceptionTypes();
+        Arrays.sort(exceptionTypes, new Comparator<Type>() {
+            @Override
+            public int compare(Type type1, Type type2) {
+                return type1.getTypeName().compareTo(type2.getTypeName());
+            }
+        });
         return TypeDefinition.Sort.describe(method.getGenericExceptionTypes()[index],
                 new TypeDescription.Generic.AnnotationReader.Delegator.ForLoadedExecutableExceptionType(method, index));
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionArrayProjectionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionArrayProjectionTest.java
@@ -44,7 +44,7 @@ public class TypeDescriptionArrayProjectionTest extends AbstractTypeDescriptionT
                 return type1.getTypeName().compareTo(type2.getTypeName());
             }
         });
-        return TypeDefinition.Sort.describe(method.getGenericExceptionTypes()[index],
+        return TypeDefinition.Sort.describe(exceptionTypes[index],
                 new TypeDescription.Generic.AnnotationReader.Delegator.ForLoadedExecutableExceptionType(method, index));
     }
 


### PR DESCRIPTION
**Test failing at:** [AbstractTypeDescriptionGenericTest.testTypeAnnotationExceptionType](https://github.com/saurabh-shetty/byte-buddy/blob/fe96422fe20ef8c286e2e766c9c2e00d6c725124/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/AbstractTypeDescriptionGenericTest.java#L1438)

**Tool used:** NonDex

**Issue:** The getGenericExceptionTypes method is used to get the exceptions in the [describeExceptionType](https://github.com/saurabh-shetty/byte-buddy/blob/fe96422fe20ef8c286e2e766c9c2e00d6c725124/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionArrayProjectionTest.java#L37) method in TypeDescriptionArrayProjectionTest.java. This getGenericExceptionTypes method doesn't guarantee the order in which the exceptions are returned (It is non deterministic). Moreover, the test assumes that the exceptions are returned in a specific order. Thus, the test was failing as it assumed that getGenericExceptionTypes returned the list of exceptions in a specific order.

**Error:**
```
[ERROR] Failures: 
[ERROR]   TypeDescriptionArrayProjectionTest>AbstractTypeDescriptionGenericTest.testTypeAnnotationExceptionType:1448 
Expected: is <NON_GENERIC>
     but: was <VARIABLE>
```
<br>

**Fix:** The returned list of exceptions by getGenericExceptionTypes method is sorted in the describeExceptionType method to ensure that the order of the exception types in the list returned is same as that expected by the test.